### PR TITLE
Declare type checking support by including `py.typed`, as per PEP 561

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,17 @@ version = 1.0.0
 classifiers =
   License :: OSI Approved :: Apache Software License
 
+
 [options]
 packages =
   matrix_common
 python_requires = >= 3.6
 install_requires =
   attrs
+
+
+[options.package_data]
+matrix_common = py.typed
 
 
 [options.extras_require]


### PR DESCRIPTION
Otherwise mypy won't pick up the type hints in downstream packages.