### PR TITLE
Include tests in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# Include tests in the source distribution
+recursive-include tests *.py


### PR DESCRIPTION
Note that this is not the same thing as marking them as packages (that get installed into site-packages) and in my test this didn't include them in the wheels either; this is purely for the source distribution (which packagers sometimes appreciate so they can check that their packages do the trick),

This is in line with what we do for Synapse and is also in line with what a lot of packages do, both in Python and out.