### PR TITLE
Remove usedevelop from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,6 @@ isolated_build = true
 
 [testenv:py]
 
-# As of twisted 16.4, trial tries to import the tests as a package (previously
-# it loaded the files explicitly), which means they need to be on the
-# pythonpath. Our sdist doesn't include the 'tests' package, so normally it
-# doesn't work within the tox virtualenv.
-#
-# As a workaround, we tell tox to do install with 'pip -e', which just
-# creates a symlink to the project directory instead of unpacking the sdist.
-usedevelop=true
-
 extras = test
 
 commands =


### PR DESCRIPTION
Removes `usedevelop=true` from `tox.ini`, which is no longer needed because #15 added the tests to the source distribution.

Also fixes errors running `tox -e py` repeatedly, which was expecting a `setup.py` previously.