### PR TITLE
Add test extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,12 @@ matrix_common = py.typed
 
 
 [options.extras_require]
-dev =
-  # for tests
+test =
   tox
   twisted
   aiounittest
+dev =
+  %(test)s
   # for type checking
   mypy == 0.910
   # for linting

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ isolated_build = true
 # creates a symlink to the project directory instead of unpacking the sdist.
 usedevelop=true
 
-extras = dev
+extras = test
 
 commands =
   python -m twisted.trial tests


### PR DESCRIPTION
Splits an `test` extra from the existing `dev` one and makes tox use it instead.

Closes #17.