### PR TITLE
Move versionstring from sydent/snapse to common

### DIFF
--- a/matrix_common/versionstring.py
+++ b/matrix_common/versionstring.py
@@ -1,0 +1,85 @@
+# Copyright 2016 OpenMarket Ltd
+# Copyright 2021 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import subprocess
+from types import ModuleType
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+version_cache: Dict[ModuleType, str] = {}
+
+
+def get_version_string(module: ModuleType) -> str:
+    """Given a module calculate a git-aware version string for it.
+
+    If called on a module not in a git checkout will return `__version__`.
+
+    Args:
+        module: The module to check the version of. Must declare a __version__
+            attribute.
+
+    Returns:
+        The module version (as a string).
+    """
+
+    cached_version = version_cache.get(module)
+    if cached_version is not None:
+        return cached_version
+
+    # We want this to fail loudly with an AttributeError. Type-ignore this so
+    # mypy only considers the happy path.
+    version_string = module.__version__  # type: ignore[attr-defined]
+
+    try:
+        cwd = os.path.dirname(os.path.abspath(module.__file__))
+
+        def _run_git_command(prefix: str, *params: str) -> str:
+            try:
+                result = (
+                    subprocess.check_output(
+                        ["git", *params], stderr=subprocess.DEVNULL, cwd=cwd
+                    )
+                    .strip()
+                    .decode("ascii")
+                )
+                return prefix + result
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                return ""
+
+        git_branch = _run_git_command("b=", "rev-parse", "--abbrev-ref", "HEAD")
+        git_tag = _run_git_command("t=", "describe", "--exact-match")
+        git_commit = _run_git_command("", "rev-parse", "--short", "HEAD")
+
+        dirty_string = "-this_is_a_dirty_checkout"
+        is_dirty = _run_git_command("", "describe", "--dirty=" + dirty_string).endswith(
+            dirty_string
+        )
+        git_dirty = "dirty" if is_dirty else ""
+
+        if git_branch or git_tag or git_commit or git_dirty:
+            git_version = ",".join(
+                s for s in (git_branch, git_tag, git_commit, git_dirty) if s
+            )
+
+            version_string = f"{version_string} ({git_version})"
+    except Exception as e:
+        logger.info("Failed to check for git repository: %s", e)
+
+    version_cache[module] = version_string
+
+    return version_string

--- a/matrix_common/versionstring.py
+++ b/matrix_common/versionstring.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import functools
 import logging
 import subprocess
 from typing import Dict
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 version_cache: Dict[str, str] = {}
 
 
+@functools.lru_cache
 def get_distribution_version_string(distribution_name: str) -> str:
     """Calculate a git-aware version string for a distribution package.
 
@@ -53,11 +54,6 @@ def get_distribution_version_string(distribution_name: str) -> str:
     Returns:
         The module version, possibly with git version information included.
     """
-
-    # TODO: let's just replace this with @functools.lrucache.
-    cached_version = version_cache.get(distribution_name)
-    if cached_version is not None:
-        return cached_version
 
     distribution = Distribution.from_name(distribution_name)
     version_string = distribution.version
@@ -96,7 +92,5 @@ def get_distribution_version_string(distribution_name: str) -> str:
             version_string = f"{version_string} ({git_version})"
     except Exception as e:
         logger.info("Failed to check for git repository: %s", e)
-
-    version_cache[distribution_name] = version_string
 
     return version_string

--- a/matrix_common/versionstring.py
+++ b/matrix_common/versionstring.py
@@ -15,7 +15,6 @@
 import functools
 import logging
 import subprocess
-from typing import Dict
 
 try:
     from importlib.metadata import distribution
@@ -25,8 +24,6 @@ except ImportError:
 __all__ = ["get_distribution_version_string"]
 
 logger = logging.getLogger(__name__)
-
-version_cache: Dict[str, str] = {}
 
 
 @functools.lru_cache()

--- a/matrix_common/versionstring.py
+++ b/matrix_common/versionstring.py
@@ -20,7 +20,7 @@ from typing import Dict
 try:
     from importlib.metadata import distribution
 except ImportError:
-    from importlib_metadata import distribution  # type: ignore[misc]
+    from importlib_metadata import distribution  # type: ignore
 
 __all__ = ["get_distribution_version_string"]
 

--- a/matrix_common/versionstring.py
+++ b/matrix_common/versionstring.py
@@ -18,9 +18,9 @@ import subprocess
 from typing import Dict
 
 try:
-    from importlib.metadata import Distribution
+    from importlib.metadata import distribution
 except ImportError:
-    from importlib_metadata import Distribution  # type: ignore[misc]
+    from importlib_metadata import distribution  # type: ignore[misc]
 
 __all__ = ["get_distribution_version_string"]
 
@@ -55,9 +55,9 @@ def get_distribution_version_string(distribution_name: str) -> str:
         The module version, possibly with git version information included.
     """
 
-    distribution = Distribution.from_name(distribution_name)
-    version_string = distribution.version
-    cwd = distribution.locate_file(".")
+    dist = distribution(distribution_name)
+    version_string = dist.version
+    cwd = dist.locate_file(".")
 
     try:
 

--- a/matrix_common/versionstring.py
+++ b/matrix_common/versionstring.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 version_cache: Dict[str, str] = {}
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def get_distribution_version_string(distribution_name: str) -> str:
     """Calculate a git-aware version string for a distribution package.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
 strict = true
+warn_unused_ignores = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ packages =
 python_requires = >= 3.6
 install_requires =
   attrs
+  importlib_metadata >= 1.4; python_version < '3.8'
 
 
 [options.package_data]

--- a/tests/test_versionstring.py
+++ b/tests/test_versionstring.py
@@ -1,0 +1,27 @@
+#  Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from unittest import TestCase
+
+from matrix_common.versionstring import get_distribution_version_string
+
+
+class TestVersionString(TestCase):
+    def test_our_own_version_string(self) -> None:
+        """Sanity check that we get the version string for our own package.
+
+        Check that it's a nonempty string.
+        """
+        version = get_distribution_version_string("matrix-common")
+        self.assertIs(type(version), str)
+        self.assertTrue(version)

--- a/tests/test_versionstring.py
+++ b/tests/test_versionstring.py
@@ -23,5 +23,5 @@ class TestVersionString(TestCase):
         Check that it's a nonempty string.
         """
         version = get_distribution_version_string("matrix-common")
-        self.assertIs(type(version), str)
+        self.assertIsInstance(version, str)
         self.assertTrue(version)


### PR DESCRIPTION
Fixes #6.

Suggest reviewing commit-by-commit.

Rather than assuming `__version__` exists, use importlib to grab package metadata. (I've done this so we don't have to duplicate the version in the source code and in the packaging config.)

```
>>> from matrix_common.versionstring import *
>>> get_distribution_version_string("matrix-common")
'1.0.0 (b=dmr/versionstring,8420421)'
```

Once merged, I'll make a minor release of the library, change synapse and sydent to require that version, and have them use the implementation in the PR.