### PR TITLE
Optionally allow a cwd for get_distribution_version_string 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ dev =
   # for type checking
   mypy == 0.910
   # for linting
-  black == 21.9b0
+  black == 22.3.0
   flake8 == 4.0.1
   isort == 5.9.3
 


### PR DESCRIPTION
Needed for https://github.com/matrix-org/synapse/issues/12968.

Since we now use `poetry-core` to build distributions for Synapse, the `locate_file(".")` trick no longer seems to work to find Synapse's source directory.

In principle we could do something like 
- have the get-a-version function accept a module object
- look up the distribution name given the module's `__name__` in `importlib.metadata.packages_distributions()`, and use that to get a version as today
- get `cwd` from the module's `__file__` attribute and use that for the git invocations

Unfortunately the second step is brittle. When I tried to test this on matrix.org's configuration, `packages_distributions()["synapse"]` gave me a KeyError for my troubles.

Instead, keep things simple and have the caller give us an optional cwd.

If accepted, I will do a minor release of matrix-python-common and change Synapse to depend on it in https://github.com/matrix-org/synapse/pull/12973 (which is presently a WIP).