### PR TITLE
Allow for setuptools to automatically discover new modules under `src/matrix_common`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@ classifiers =
 
 
 [options]
-package_dir = =src
-packages =
-  matrix_common
 python_requires = >= 3.7
 install_requires =
   attrs


### PR DESCRIPTION
While trying to add a Python module at `src/matrix_common/types`, I ran into the issue that `pip install -e .` would not actually find the new module! This would result in calls to `tox -e py` to fail as my new module wouldn't be included in the source distribution of `matrix_common` (which tox builds and installs when creating its own virtualenv for testing). My tests needed to import from this new module in order to test it.

So, running down the rabbit hole of python packaging I eventually found that our existing `setup.cfg` was not making use of setuptools' autodiscovery features, but instead required manually specifying each package. See the [documentation here](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#package-discovery-and-namespace-packages).

Adding my new module to `packages` indeed worked, but as the documentation says, it is tiresome and likely going to confuse new contributors as it did me.

---

This PR removes the `package_dir` and `packages` options in `setup.cfg` to allow setuptools to switch to [Automatic Discovery](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#automatic-discovery) mode for packages; specifically the one for `src-layout`.

With this, running `pip install -e .` allowed my `src/matrix_common/types` module to be discovered and my tests which import the module to pass with when running `tox`.

Related: https://github.com/matrix-org/matrix-python-common/pull/23 (which moved us to a src-based file hierarchy initially).