### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         # Run the unit tests both against our oldest supported Python version
         # and the newest stable.
-        python_version: [ "3.6", "3.x" ]
+        python_version: [ "3.7", "3.x" ]
     steps: 
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
 package_dir = =src
 packages =
   matrix_common
-python_requires = >= 3.6
+python_requires = >= 3.7
 install_requires =
   attrs
   importlib_metadata >= 1.4; python_version < '3.8'


### PR DESCRIPTION
Python 3.6 became [end of life](https://endoflife.date/python) December 2021. This PR:

* Notes that 3.7+ is required in `setup.cfg`.
* Updates the "oldest" Python version to be 3.7 in CI.