### PR TITLE
Allow importing `MXCUri` from `matrix_common.types`

### DIFF
--- a/src/matrix_common/types/__init__.py
+++ b/src/matrix_common/types/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2022 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .mxc_uri import MXCUri
+
+# Allow importing classes directly from matrix_common.types.
+__all__ = ["MXCUri"]


### PR DESCRIPTION
Overlooked in https://github.com/matrix-org/matrix-python-common/pull/29. Allows for cleaner import statements.