### PR TITLE
Require at least setuptools version 61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]


### PR DESCRIPTION
Use of the automatic discovery feature was introduced with PR #27. The feature is only available in setuptools version 61 and later, though, which this change documents in pyproject.toml.